### PR TITLE
Pin esbuild version and add structured change log

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+changes.jsonl merge=union

--- a/changes.jsonl
+++ b/changes.jsonl
@@ -1,0 +1,28 @@
+{"type":"release","version":"1.0.0","date":"2025-08-27"}
+{"description":"Prevent errors when deleting files from aborting the build process","category":"change"}
+{"type":"release","version":"1.1.0","date":"2025-09-22"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.1.1","date":"2025-10-24"}
+{"description":"Fix audit vulnerabilities","category":"fix"}
+{"type":"release","version":"1.1.2","date":"2025-10-24"}
+{"description":"Fix audit vulnerabilities","category":"fix"}
+{"type":"release","version":"1.1.3","date":"2026-02-02"}
+{"description":"Added features option to enable/disable specific plugin features","category":"feature"}
+{"description":"Added empty directory removal feature (enabled by default)","category":"feature"}
+{"description":"Added custom logger support via logger option","category":"feature"}
+{"type":"release","version":"1.2.0","date":"2026-02-02"}
+{"description":"Fixed [CVE-2026-25547] in @isaacs/brace-expansion","category":"security","metadata":{"cve":"CVE-2026-25547","ghsa":"GHSA-7h2j-956f-4vf2"}}
+{"type":"release","version":"1.2.1","date":"2026-02-04"}
+{"description":"Fixed [CVE-2025-68458] in webpack","category":"security","metadata":{"cve":"CVE-2025-68458","ghsa":"GHSA-8fgc-7cc6-rx7x"}}
+{"description":"Fixed [CVE-2025-68157] in webpack","category":"security","metadata":{"cve":"CVE-2025-68157","ghsa":"GHSA-38r7-794h-5758"}}
+{"type":"release","version":"1.2.2","date":"2026-02-09"}
+{"description":"Fixed [CVE-2026-27959] in koa","category":"security","metadata":{"cve":"CVE-2026-27959","ghsa":"GHSA-7gcc-r8m5-44qm"}}
+{"description":"Fixed [GHSA-3ppc-4f35-3m26] in minimatch","category":"security","metadata":{"ghsa":"GHSA-3ppc-4f35-3m26"}}
+{"type":"release","version":"1.2.3","date":"2026-02-28"}
+{"description":"Fixed [GHSA-5c6j-r48x-rmvq] in serialize-javascript","category":"security","metadata":{"ghsa":"GHSA-5c6j-r48x-rmvq"}}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.2.4","date":"2026-03-01"}
+{"description":"Added rolldown plugin export","category":"feature"}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.0","date":"2026-03-11"}
+{"description":"Pin esbuild version to silence false Dependabot CVE alerts","category":"change"}

--- a/packages/build-clean/package.json
+++ b/packages/build-clean/package.json
@@ -191,7 +191,7 @@
     "@farmfe/core": ">=1",
     "@nuxt/kit": "^3",
     "@nuxt/schema": "^3",
-    "esbuild": "*",
+    "esbuild": "^0.27",
     "rolldown": ">=1.0.0-rc.1",
     "rollup": "^3",
     "vite": "^6",
@@ -227,6 +227,7 @@
     "@nuxt/kit": "^4.3.1",
     "@tsconfig/node22": "^22.0.5",
     "@types/node": "^25.4.0",
+    "esbuild": "^0.27.3",
     "terser": "^5.46.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       '@nuxt/schema':
         specifier: ^3
         version: 3.21.1
-      esbuild:
-        specifier: '*'
-        version: 0.27.3
       rolldown:
         specifier: '>=1.0.0-rc.1'
         version: 1.0.0-rc.8
@@ -157,6 +154,9 @@ importers:
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
       terser:
         specifier: ^5.46.0
         version: 5.46.0


### PR DESCRIPTION
## Summary

- Pin esbuild to ^0.27.3 to suppress false Dependabot CVE alerts
- Add changes.jsonl as structured change log converted from CHANGELOG.md
- Add .gitattributes with merge=union for conflict-free JSONL updates