### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.2] - 2026-03-28
+
+### Changed
+
+- Pin esbuild version to silence false Dependabot CVE alerts
+
 ## [1.3.1] - 2026-03-28
 
 ### Security
@@ -88,6 +94,7 @@
 
 Initial release.
 
+[1.3.2]: https://github.com/shellicar/build-clean/releases/tag/1.3.2
 [1.3.1]: https://github.com/shellicar/build-clean/releases/tag/1.3.1
 [1.3.0]: https://github.com/shellicar/build-clean/releases/tag/1.3.0
 [1.2.4]: https://github.com/shellicar/build-clean/releases/tag/1.2.4

--- a/changes.jsonl
+++ b/changes.jsonl
@@ -25,4 +25,10 @@
 {"description":"Added rolldown plugin export","category":"feature"}
 {"description":"Updated all dependencies to latest versions","category":"change"}
 {"type":"release","version":"1.3.0","date":"2026-03-11"}
+{"description":"Fixed [CVE-2026-32887] in effect","category":"security","metadata":{"cve":"CVE-2026-32887","ghsa":"GHSA-38f7-945m-qr2g"}}
+{"description":"Fixed [CVE-2026-33671] in picomatch","category":"security","metadata":{"cve":"CVE-2026-33671","ghsa":"GHSA-c2c7-rcm5-vvqj"}}
+{"description":"Fixed [CVE-2026-33750] in brace-expansion","category":"security","metadata":{"cve":"CVE-2026-33750","ghsa":"GHSA-f886-m6hf-6m8v"}}
+{"description":"Updated all dependencies to latest versions","category":"change"}
+{"type":"release","version":"1.3.1","date":"2026-03-28"}
 {"description":"Pin esbuild version to silence false Dependabot CVE alerts","category":"change"}
+{"type":"release","version":"1.3.2","date":"2026-03-28"}

--- a/packages/build-clean/package.json
+++ b/packages/build-clean/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shellicar/build-clean",
   "private": false,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "license": "MIT",
   "author": "Stephen Hellicar",


### PR DESCRIPTION
## Summary

- Bump version to 1.3.2
- Add esbuild version pin to CHANGELOG and changes.jsonl